### PR TITLE
Jm funspec additions puretest errors

### DIFF
--- a/scalaz/src/main/scala/Filter.scala
+++ b/scalaz/src/main/scala/Filter.scala
@@ -13,7 +13,7 @@ object Filter{
 
   def apply[F[_]](implicit S: Filter[F]) = S
 
-  object syntax {
+  trait Syntax {
 
     implicit class FilterOps[F[_],A](fa: F[A])(implicit SF: Filter[F]){
       def filter(f: A => Boolean)(implicit F: sourcecode.File, L: sourcecode.Line): F[A] =
@@ -22,6 +22,8 @@ object Filter{
         filter(f)
     }
   }
+
+  object Syntax extends Syntax
 
   implicit def FilterForMonadError[F[_], E](implicit
       M: Monad[F], HE: HandleError[F,E], RE: RaiseError[F, PureTestError[E]]) =

--- a/scalaz/src/main/scala/FunSpec.scala
+++ b/scalaz/src/main/scala/FunSpec.scala
@@ -1,6 +1,7 @@
 package org.hablapps.puretest
 
 trait FunSpec[P[_],E] {
+  implicit val HE: HandleError[P, E]
   implicit val RE: RaiseError[P, PureTestError[E]]
 
   def Describe(subject: String)(test: => Unit): Unit
@@ -8,6 +9,5 @@ trait FunSpec[P[_],E] {
   def It[A](condition: String)(program: => P[A]): Unit
 
   def Holds(condition: String)(program: => P[Boolean]): Unit
-
 }
 

--- a/scalaz/src/main/scala/FunSpec.scala
+++ b/scalaz/src/main/scala/FunSpec.scala
@@ -1,6 +1,7 @@
 package org.hablapps.puretest
 
-trait FunSpec[P[_]] {
+trait FunSpec[P[_],E] {
+  implicit val RE: RaiseError[P, PureTestError[E]]
 
   def Describe(subject: String)(test: => Unit): Unit
 

--- a/scalaz/src/main/scala/package.scala
+++ b/scalaz/src/main/scala/package.scala
@@ -5,7 +5,8 @@ package object puretest
   with StateTEqual
   with StateTArbitrary
   with StateValidationMonad
-  with MonadErrorUtils{
+  with MonadErrorUtils
+  with Filter.Syntax{
 
   type Location = (sourcecode.File, sourcecode.Line)
 

--- a/scalaz/src/main/scala/scalatest/FunSpec.scala
+++ b/scalaz/src/main/scala/scalatest/FunSpec.scala
@@ -3,7 +3,7 @@ package scalatestImpl
 
 trait ScalatestFunSpec[P[_],E] extends org.scalatest.FunSpec
   with org.scalatest.Matchers
-  with FunSpec[P] {
+  with FunSpec[P,E] {
 
   implicit val Tester: Tester[P,PureTestError[E]]
 

--- a/scalaz/src/main/scala/utils/StateTMonadError.scala
+++ b/scalaz/src/main/scala/utils/StateTMonadError.scala
@@ -2,8 +2,7 @@ package org.hablapps.puretest
 
 import scalaz.{MonadError, StateT, IndexedStateT}
 
-trait StateTMonadError extends LowerPriorityImplicits{
-
+trait StateTMonadError{
 
   implicit def stateTMonadError[S, F[_], E](implicit F: MonadError[F, E]) =
     new MonadError[StateT[F, S, ?], E]{
@@ -15,7 +14,8 @@ trait StateTMonadError extends LowerPriorityImplicits{
         StateT(s => F.point(s, aa.value))
       }
 
-      def bind[A, B](fa: StateT[F, S, A])(f: A => StateT[F, S, B]): StateT[F, S, B] = fa.flatMap(f)
+      def bind[A, B](fa: StateT[F, S, A])(f: A => StateT[F, S, B]): StateT[F, S, B] =
+        fa.flatMap(f)
 
       def raiseError[A](e: E): StateT[F,S,A] =
         IndexedStateT(_ => F.raiseError(e))
@@ -29,24 +29,4 @@ trait StateTMonadError extends LowerPriorityImplicits{
             }
           )
     }
-}
-
-trait LowerPriorityImplicits{
-
-  implicit def toMonadError[P[_],E](implicit 
-    toE: PureTestError[E] => Option[E],
-    fromE: E => PureTestError[E],
-    ME: MonadError[P,PureTestError[E]]) = 
-    new MonadError[P,E]{
-      def point[A](a: => A) = ME.point(a)
-      def bind[A,B](p: P[A])(f: A => P[B]) = ME.bind(p)(f)
-      def raiseError[A](e: E) =
-        ME.raiseError(fromE(e))
-      def handleError[A](p: P[A])(f: E => P[A]) =
-        ME.handleError(p){ e2 => toE(e2) match {
-          case Some(e1) => f(e1)
-          case None => ME.raiseError(e2)
-        }}
-    }
-
 }

--- a/scalaz/src/test/scala/Boolean.scala
+++ b/scalaz/src/test/scala/Boolean.scala
@@ -3,7 +3,6 @@ package test
 
 import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monad._
-import Filter.syntax._
 
 trait BooleanPrograms[P[_]] extends FunSpec[P,Throwable]{
 

--- a/scalaz/src/test/scala/Boolean.scala
+++ b/scalaz/src/test/scala/Boolean.scala
@@ -5,11 +5,10 @@ import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monad._
 import Filter.syntax._
 
-trait BooleanPrograms[P[_]]{
+trait BooleanPrograms[P[_]] extends FunSpec[P,Throwable]{
 
   val MS: MonadState[P, Int]
   implicit val ME: MonadError[P, Throwable]
-  implicit val RE: RaiseError[P, PureTestError[Throwable]]
 
   def trueProgram: P[Boolean] = for {
     _ <- MS.put(1)
@@ -26,15 +25,4 @@ trait BooleanPrograms[P[_]]{
 
   def raisedErrorBoolProgram: P[Boolean] =
     RE.raiseError(new RuntimeException("forced exception"))
-}
-
-object BooleanPrograms{
-  def apply[P[_]](implicit _MS: MonadState[P,Int], 
-    _RE: RaiseError[P,PureTestError[Throwable]],
-    _ME: MonadError[P,Throwable]) =
-    new BooleanPrograms[P]{
-      val MS = _MS
-      val ME = _ME
-      val RE = _RE
-    }
 }

--- a/scalaz/src/test/scala/BooleanSpec.scala
+++ b/scalaz/src/test/scala/BooleanSpec.scala
@@ -5,9 +5,7 @@ import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monad._
 import Filter.syntax._
 
-trait BooleanSpec[P[_]] extends FunSpec[P] {
-  val S: BooleanPrograms[P]
-  import S._
+trait BooleanSpec[P[_]] extends BooleanPrograms[P]{
 
   Describe("Boolean programs"){
     Holds("if return true"){
@@ -47,7 +45,9 @@ trait BooleanSpec[P[_]] extends FunSpec[P] {
 
 object BooleanSpec{
   class Scalatest[P[_]](
-    val S: BooleanPrograms[P],
+    val MS: MonadState[P,Int],
+    val ME: MonadError[P,Throwable],
+    val RE: RaiseError[P,PureTestError[Throwable]],
     val Tester: Tester[P,PureTestError[Throwable]])
   extends scalatestImpl.ScalatestFunSpec[P,Throwable] with BooleanSpec[P]
 }

--- a/scalaz/src/test/scala/BooleanSpec.scala
+++ b/scalaz/src/test/scala/BooleanSpec.scala
@@ -46,6 +46,7 @@ object BooleanSpec{
   class Scalatest[P[_]](
     val MS: MonadState[P,Int],
     val ME: MonadError[P,Throwable],
+    val HE: HandleError[P,Throwable],
     val RE: RaiseError[P,PureTestError[Throwable]],
     val Tester: Tester[P,PureTestError[Throwable]])
   extends scalatestImpl.ScalatestFunSpec[P,Throwable] with BooleanSpec[P]

--- a/scalaz/src/test/scala/BooleanSpec.scala
+++ b/scalaz/src/test/scala/BooleanSpec.scala
@@ -3,7 +3,6 @@ package test
 
 import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monad._
-import Filter.syntax._
 
 trait BooleanSpec[P[_]] extends BooleanPrograms[P]{
 

--- a/scalaz/src/test/scala/BooleanSpecStateT.scala
+++ b/scalaz/src/test/scala/BooleanSpecStateT.scala
@@ -12,6 +12,7 @@ class BooleanSpecStateT extends BooleanSpec.Scalatest[Program](
   implicitly,
   implicitly,
   implicitly,
+  implicitly,
   StateTester[Program,Int,PureTestError[Throwable]].apply(0)
 )
 

--- a/scalaz/src/test/scala/BooleanSpecStateT.scala
+++ b/scalaz/src/test/scala/BooleanSpecStateT.scala
@@ -9,7 +9,9 @@ import scalaz._, Scalaz._
 import BooleanSpecStateT.Program
 
 class BooleanSpecStateT extends BooleanSpec.Scalatest[Program](
-  BooleanPrograms[Program],
+  implicitly,
+  implicitly,
+  implicitly,
   StateTester[Program,Int,PureTestError[Throwable]].apply(0)
 )
 

--- a/scalaz/src/test/scala/ShouldSpec.scala
+++ b/scalaz/src/test/scala/ShouldSpec.scala
@@ -5,20 +5,19 @@ import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monadError._
 import Filter.syntax._
 
-import WorkingProgram.Error 
+import WorkingProgram.Error
 
-trait ShouldSpec[P[_]] extends FunSpec[P] {
+trait ShouldSpec[P[_]] extends FunSpec[P,PureTestError[Error]] {
   val S: WorkingProgram[P]
   import S._
-  
+
   implicit val RE1: RaiseError[P, PureTestError[Error]]
   implicit val HE1: HandleError[P, PureTestError[Error]]
-  implicit val RE2: RaiseError[P, PureTestError[PureTestError[Error]]]
 
   Describe("ShouldFail should fail"){
     It("with working programs"){
       workingProgram.shouldFail[Error].
-        shouldFail[PureTestError[Error]](NotFailed[Error,Int](1)) >> 
+        shouldFail[PureTestError[Error]](NotFailed[Error,Int](1)) >>
       (for {
         2 <- workingProgramWithHandledError
       } yield ()).shouldFail[Error].shouldFail[PureTestError[Error]]
@@ -54,12 +53,12 @@ trait ShouldSpec[P[_]] extends FunSpec[P] {
       failingProgram.shouldSucceed[Error]
         .shouldFail[PureTestError[Error]](NotSucceeded[Error](Error(0)))
     }
-    
+
     It("if expected value doesn't equal actual value"){
       workingProgram.shouldBe[Error](2)
         .shouldFail[PureTestError[Error]](NotEqualTo[Error,Int](1,2))
     }
-    
+
     It("if it doesn't match actual value"){
       (MS.put(1) >> MS.get).shouldMatch[Error]{ _ == 2 }
         .shouldFail[PureTestError[Error]]
@@ -71,12 +70,12 @@ trait ShouldSpec[P[_]] extends FunSpec[P] {
       workingProgram.shouldSucceed[Error]
         .shouldBe[PureTestError[Error]](1)
     }
-    
+
     It("if expected value equals actual value"){
       workingProgram.shouldBe[Error](1)
         .shouldBe[PureTestError[Error]](1)
     }
-    
+
     It("if it matches actual value"){
       (MS.put(1) >> MS.get).shouldMatch[Error]{ _ == 1 }
         .shouldBe[PureTestError[Error]](1)
@@ -89,7 +88,7 @@ object ShouldSpec{
     val S: WorkingProgram[P],
     val RE1: RaiseError[P, PureTestError[Error]],
     val HE1: HandleError[P, PureTestError[Error]],
-    val RE2: RaiseError[P, PureTestError[PureTestError[Error]]],
+    val RE: RaiseError[P, PureTestError[PureTestError[Error]]],
     val Tester: Tester[P,PureTestError[PureTestError[Error]]])
   extends scalatestImpl.ScalatestFunSpec[P,PureTestError[Error]]
   with ShouldSpec[P]

--- a/scalaz/src/test/scala/ShouldSpec.scala
+++ b/scalaz/src/test/scala/ShouldSpec.scala
@@ -2,9 +2,7 @@ package org.hablapps.puretest
 package test
 
 import scalaz.{MonadState, MonadError}
-import scalaz.syntax.monadError._
-import Filter.syntax._
-
+import scalaz.syntax.monad._
 import WorkingProgram.Error
 
 trait ShouldSpec[P[_]] extends FunSpec[P,PureTestError[Error]] {

--- a/scalaz/src/test/scala/ShouldSpec.scala
+++ b/scalaz/src/test/scala/ShouldSpec.scala
@@ -10,7 +10,6 @@ trait ShouldSpec[P[_]] extends FunSpec[P,PureTestError[Error]] {
   import S._
 
   implicit val RE1: RaiseError[P, PureTestError[Error]]
-  implicit val HE1: HandleError[P, PureTestError[Error]]
 
   Describe("ShouldFail should fail"){
     It("with working programs"){
@@ -85,7 +84,7 @@ object ShouldSpec{
   class Scalatest[P[_]](
     val S: WorkingProgram[P],
     val RE1: RaiseError[P, PureTestError[Error]],
-    val HE1: HandleError[P, PureTestError[Error]],
+    val HE: HandleError[P, PureTestError[Error]],
     val RE: RaiseError[P, PureTestError[PureTestError[Error]]],
     val Tester: Tester[P,PureTestError[PureTestError[Error]]])
   extends scalatestImpl.ScalatestFunSpec[P,PureTestError[Error]]

--- a/scalaz/src/test/scala/ShouldSpecStateT.scala
+++ b/scalaz/src/test/scala/ShouldSpecStateT.scala
@@ -10,10 +10,8 @@ import scalaz._, Scalaz._
 import WorkingProgram.Error, ShouldSpecStateT.Program
 
 class ShouldSpecStateT extends ShouldSpec.Scalatest[Program](
-  WorkingProgram[Program](implicitly, 
-    toMonadError(PureTestError.fromPureTestError[Error] _,
-      PureTestError.toPureTestError[Error] _,
-      MonadError[Program,PureTestError[Error]])),
+  WorkingProgram[Program](implicitly,
+    PureTestError.toMonadError(MonadError[Program,PureTestError[Error]])),
   RaiseError[Program,PureTestError[Error]],
   HandleError[Program,PureTestError[Error]],
   RaiseError[Program,PureTestError[PureTestError[Error]]],

--- a/scalaz/src/test/scala/Working.scala
+++ b/scalaz/src/test/scala/Working.scala
@@ -3,7 +3,6 @@ package test
 
 import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monadError._
-import Filter.syntax._
 
 /** Programs */
 
@@ -17,7 +16,7 @@ trait WorkingProgram[P[_]]{
   def workingProgram: P[Int] =
     1.point[P]
 
-  def workingProgramReturnsOne: P[Int] = 
+  def workingProgramReturnsOne: P[Int] =
     1.point[P]
 
   def workingProgramWithHandledError: P[Int] =

--- a/scalaz/src/test/scala/WorkingSpec.scala
+++ b/scalaz/src/test/scala/WorkingSpec.scala
@@ -62,6 +62,7 @@ trait WorkingSpec[P[_]] extends FunSpec[P,Error] {
 object WorkingSpec{
   class Scalatest[P[_]](
     val S: WorkingProgram[P],
+    val HE: HandleError[P,Error],
     val RE: RaiseError[P,PureTestError[Error]],
     val Tester: Tester[P,PureTestError[Error]])
   extends scalatestImpl.ScalatestFunSpec[P,Error]

--- a/scalaz/src/test/scala/WorkingSpec.scala
+++ b/scalaz/src/test/scala/WorkingSpec.scala
@@ -3,7 +3,6 @@ package test
 
 import scalaz.{MonadState, MonadError}
 import scalaz.syntax.monadError._
-import Filter.syntax._
 
 import WorkingProgram.Error
 

--- a/scalaz/src/test/scala/WorkingSpec.scala
+++ b/scalaz/src/test/scala/WorkingSpec.scala
@@ -7,10 +7,9 @@ import Filter.syntax._
 
 import WorkingProgram.Error
 
-trait WorkingSpec[P[_]] extends FunSpec[P] {
+trait WorkingSpec[P[_]] extends FunSpec[P,Error] {
   val S: WorkingProgram[P]
   import S._
-  implicit val RE: RaiseError[P, PureTestError[Error]]
 
   Describe("ShouldSucceed"){
 

--- a/scalaz/src/test/scala/WorkingSpecStateT.scala
+++ b/scalaz/src/test/scala/WorkingSpecStateT.scala
@@ -11,6 +11,7 @@ import WorkingProgram.Error, WorkingSpecStateT.Program
 
 class WorkingSpecStateT extends WorkingSpec.Scalatest[Program](
   WorkingProgram[Program],
+  HandleError[Program,Error],
   RaiseError[Program,PureTestError[Error]],
   StateTester[Program,Int,PureTestError[Error]].apply(0)
 )


### PR DESCRIPTION
@javierfs89 

* Filter syntax moved to puretest package
* HandleError[P,E] and RaiseError[P,PureTestError[E]] moved to FunSpec

Updated geofence example [here](https://github.com/jserranohidalgo/geofences/tree/geofences-doobie/geofences-mysql/src/test/scala).